### PR TITLE
fix image tags in doc

### DIFF
--- a/docs/user-guide/101/basic-search.md
+++ b/docs/user-guide/101/basic-search.md
@@ -10,21 +10,18 @@ This guide walks you through the basics of running a search and understanding th
   </div>
 </div>
 
+
 ## 1. Performing a Search
 At the top of every page is the global search bar. To perform a basic search, type a keyword, such as a name, company, or location and press `Enter`.
 
-<div align="center">
-  <img src="../../assets/images/simple_search.png" alt="The OpenAleph search bar" width="600"/>
-</div>
+![The OpenAleph search bar](../../assets/images/simple_search.png){style="width:600px; margin:auto; display:block"}
 
 This will show you matching entities, such as Documents, Persons, Companies, or other relevant types.
 
 ## 2. Setting Alerts
 Click the `alerts icon` to the right of the search bar to receive email notifications whenever new data added mentions this search.
 
-<div align="center">
-  <img src="../../../assets/images/alerts.png" alt="The OpenAleph search bar with alerts" width="600"/>
-</div>
+![The OpenAleph search bar with alerts](../../assets/images/alerts.png){style="width:600px; margin:auto; display:block"}
 
 ## 3. Understanding the Results
 
@@ -32,25 +29,19 @@ The search results page is split into several sections:
 
 **Filter Sidebar**
 
-<div align="center">
-  <img src="../../../assets/images/search_filter.png" alt="The OpenAleph search filters" width="600"/>
-</div>
+![The OpenAleph search filters](../../assets/images/search_filter.png){style="width:600px; margin:auto; display:block"}
 
 On the left, you’ll find filters you can apply to narrow your results by dataset, date, schema type, or other criteria.
 
 **Results List**
 
-<div align="center">
-  <img src="../../../assets/images/resultlist.png" alt="The OpenAleph search result list" width="800"/>
-</div>
+![The OpenAleph search result list](../../assets/images/resultlist.png){style="width:800px; margin:auto; display:block"}
 
 In the main area, results are grouped by relevance. Each item shows a title, snippet of matched content, and metadata.
 
 ## 4. Previewing a Result
 
-<div align="center">
-  <img src="../../../assets/images/result_preview.png" alt="The OpenAleph search result preview" width="800"/>
-</div>
+![The OpenAleph search result preview](../../assets/images/result_preview.png){style="width:800px; margin:auto; display:block"}
 
 Click on any document or entity to open its preview pane:
 

--- a/docs/user-guide/101/homepage.md
+++ b/docs/user-guide/101/homepage.md
@@ -4,9 +4,7 @@ Upon logging into OpenAleph, you're presented with the homepage, a central hub f
 
 ## Top Menu
 
-<div align="center">
-  <img src="../../assets/images/top-bar.png" alt="Screenshot of the OpenAleph top menu" width="1000"/>
-</div>
+![Screenshot of the OpenAleph top menu](../../assets/images/top-bar.png){style="width:1000px; margin:auto; display:block"}
 
 The top menu offers quick access to key features:
 
@@ -22,9 +20,7 @@ The top menu offers quick access to key features:
 
 ## Side Menu
 
-<div align="center">
-  <img src="../../assets/images/side-bar.png" alt="Screenshot of the OpenAleph side menu" width="300"/>
-</div>
+![Screenshot of the OpenAleph side menu](../../assets/images/side-bar.png){style="width:300px; margin:auto; display:block"}
 
 The side menu provides additional navigation options:
 

--- a/docs/user-guide/102/advanced-search.md
+++ b/docs/user-guide/102/advanced-search.md
@@ -4,9 +4,7 @@ OpenAleph’s advanced search capabilities let you perform more precise and comp
 
 Most of the options below can be accessed and configured through the advanced search menu, available via the grey slider icon next to the main search bar. Note that property searches cannot currently be configured through the user interface.
 
-<div align="center">
-  <img src="../../assets/images/advanced_search.png" alt="Screenshot of the OpenAleph advanced search" width="600"/>
-</div>
+![Screenshot of the OpenAleph advanced search](../../assets/images/advanced_search.png){style="width:600px; margin:auto; display:block"}
 
 ## Exact Phrase Search
 

--- a/docs/user-guide/102/dataset-overview.md
+++ b/docs/user-guide/102/dataset-overview.md
@@ -14,9 +14,7 @@ It's common for datasets to contain both structured and unstructed data.
 
 ## Viewing a Dataset
 
-<div align="center">
-  <img src="../../assets/images/dataset_overview.png" alt="Screenshot of the OpenAleph dataset overview" width="1000"/>
-</div>
+![Screenshot of the OpenAleph dataset overview](../../assets/images/dataset_overview.png){style="width:1000px; margin:auto; display:block"}
 
 To view a dataset:
 

--- a/docs/user-guide/102/dataset-search.md
+++ b/docs/user-guide/102/dataset-search.md
@@ -8,18 +8,14 @@ There are two primary ways to restrict your search to a specific dataset:
 
 ### 1. From the Dataset Page
 
-<div align="center">
-  <img src="../../assets/images/dataset_search.png" alt="Screenshot of the OpenAleph dataset overview" width="400"/>
-</div>
+![Screenshot of the OpenAleph dataset overview](../../assets/images/dataset_search.png){style="width:400px; margin:auto; display:block"}
 
 1. Open the dataset from the **Datasets** tab.
 2. Use the search bar within the dataset view. This automatically scopes your search to that dataset.
 
 ### 2. Using Filters
 
-<div align="center">
-  <img src="../../assets/images/dataset_filter.png" alt="Screenshot of the OpenAleph filter bar" width="300"/>
-</div>
+![Screenshot of the OpenAleph filter bar](../../assets/images/dataset_filter.png){style="width:300px; margin:auto; display:block"}
 
 On a general search results page:
 
@@ -29,17 +25,13 @@ On a general search results page:
 
 ## Extracted `mentions` search
 
-<div align="center">
-  <img src="../../assets/images/mentions_search.png" alt="Screenshot of the OpenAleph mentions search" width="600"/>
-</div>
+![Screenshot of the OpenAleph mentions search](../../assets/images/mentions_search.png){style="width:600px; margin:auto; display:block"}
 
 OpenAleph extracts several identifiers from the dataset during ingestion. You can click these identifiers on the overview page to see all entities or files containing them within the dataset.
 
 ## Source documents
 
-<div align="center">
-  <img src="../../assets/images/source_docs.png" alt="Screenshot of the OpenAleph dataset overview" width="600"/>
-</div>
+![Screenshot of the OpenAleph dataset overview](../../assets/images/source_docs.png){style="width:600px; margin:auto; display:block"}
 
 If the dataset contains documents and folders, you can browse these sources by clicking the source documents tab, similar to browsing folder structures on your computer.
 

--- a/docs/user-guide/103/investigations.md
+++ b/docs/user-guide/103/investigations.md
@@ -36,9 +36,7 @@ To create an investigation:
 
 ## Uploading Content
 
-<div align="center">
-  <img src="../../assets/images/upload_files.png" alt="Screenshot of the OpenAleph content upload menu" width="400"/>
-</div>
+![Screenshot of the OpenAleph content upload menu](../../assets/images/upload_files.png){style="width:400px; margin:auto; display:block"}
 
 Once your workspace is created, you can upload:
 

--- a/docs/user-guide/103/manage-access.md
+++ b/docs/user-guide/103/manage-access.md
@@ -20,14 +20,10 @@ To share a workspace with others:
 
 1. Open the workspace.
 2. Click the **Gear icon** in the top right corner and select **Share** from the dropdown menu.
-<div align="center">
-  <img src="../../assets/images/investigation_settings.png" alt="Screenshot of the investigation settings menu" width="400"/>
-</div>
+![Screenshot of the investigation settings menu](../../assets/images/investigation_settings.png){style="width:400px; margin:auto; display:block"}
 
 4. Enter the email address or username of the person you want to invite.
-<div align="center">
-  <img src="../../assets/images/share_access.png" alt="Screenshot of the investigation sharing menu" width="400"/>
-</div>
+![Screenshot of the investigation sharing menu](../../assets/images/share_access.png){style="width:400px; margin:auto; display:block"}
 
 5. Assign a role:
 	- **View**: Can see content, but cannot make changes.

--- a/docs/user-guide/103/map-data.md
+++ b/docs/user-guide/103/map-data.md
@@ -24,9 +24,7 @@ This is especially useful for:
 
 1. Upload a CSV or Excel file to your investigation workspace.
 2. After upload, click the **Generate Entities** option.
-<div align="center">
-  <img src="../../assets/images/csv_view.png" alt="Screenshot of the OpenAleph table view" width="600"/>
-</div>
+![Screenshot of the OpenAleph table view](../../assets/images/csv_view.png){style="width:600px; margin:auto; display:block"}
 
 3. In section 1, choose the target schema (e.g. `LegalEntity`, `Person`, `Asset`). You can find a full list of supported schemata in the FtM data model [here](https://followthemoney.tech/explorer/#schemata). You may create more than one entity type from a single file. Keep in mind that in OpenAleph, connections are also treated as entities, so be sure to create those here as well.
 4. In section 2, use the interface to assign each column in your file to a schema property.
@@ -34,9 +32,7 @@ This is especially useful for:
 6. OpenAleph will then create new entities from the mapped rows.
 
 This is what a simple mapping looks like that turns a table with bank accounts, some properties and ownership information into entities.
-<div align="center">
-  <img src="../../assets/images/mapping.png" alt="Screenshot of the OpenAleph mapping view" width="1000"/>
-</div>
+![Screenshot of the OpenAleph mapping view](../../assets/images/mapping.png){style="width:1000px; margin:auto; display:block"}
 
 
 ## Tips for Effective Mapping

--- a/docs/user-guide/103/network-diagrams.md
+++ b/docs/user-guide/103/network-diagrams.md
@@ -7,9 +7,6 @@ Network diagrams in OpenAleph let you visually explore relationships between ent
 Network diagrams are interactive graphs that show entities (like people, companies, or assets) as nodes, and their relationships (like ownership or affiliation) as edges between them.
 
 They are generated directly from structured data within an investigation workspace.
-<div align="center">
-  <img src="../../assets/images/dia.png" alt="Screenshot of a network diagram" width="600"/>
-</div>
 
 <div>
   <div style="position:relative;padding-top:56.25%;">
@@ -24,21 +21,15 @@ They are generated directly from structured data within an investigation workspa
 1. Go to your **Investigation**.
 2. Select **Network Diagrams** from the sidebar.
 3. Click **New Diagram**.
-<div align="center">
-  <img src="../../assets/images/new_dia.png" alt="Screenshot of the new network diagram dialog" width="400"/>
-</div>
+![Screenshot of the new network diagram dialog](../../assets/images/new_dia.png){style="width:400px; margin:auto; display:block"}
 
 
 4. Add entities from your investigation
-<div align="center">
-  <img src="../../assets/images/add_to_dia.png" alt="Screenshot of the add entity to network diagram dialog" width="400"/>
-</div>
+![Screenshot of the add entity to network diagram dialog](../../assets/images/add_to_dia.png){style="width:400px; margin:auto; display:block"}
 
 
 5. Expand each entity with a double click, then select `Discover asset and shares`
-<div align="center">
-  <img src="../../assets/images/expand_dia.png" alt="Screenshot of the expand entity to network diagram dialog" width="400"/>
-</div>
+![Screenshot of the expand entity to network diagram dialog](../../assets/images/expand_dia.png){style="width:400px; margin:auto; display:block"}
 
 
 6. Repeat step 6 with the newly discovered entities, if you want.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,8 @@ markdown_extensions:
   - admonition
   - pymdownx.tasklist:
       custom_checkbox: true
+  - attr_list
+  - md_in_html
 plugins:
   - search
   # - mkdocstrings:


### PR DESCRIPTION
Some of the image tags where broken, this pr fixes the paths and changes all tags to proper markdown. It also adds the required mkdocs extension to format the images.