### PR TITLE
Update UI and docs from alephclient to openaleph CLI

### DIFF
--- a/docs/user-guide/104/cli.md
+++ b/docs/user-guide/104/cli.md
@@ -127,7 +127,7 @@ Run all entities from a dataset through [`jq`](https://jqlang.org/) and filter o
 ```bash
 curl -o us_ofac.json hhttps://data.opensanctions.org/datasets/latest/us_sanctions/entities.ftm.json
 cat us_ofac.json | ftm store write -d us_ofac
-ftm store iterate -d us_ofac | alephclient write-entities -f us_ofac
+ftm store iterate -d us_ofac | openaleph write-entities -f us_ofac
 ftm store delete -d us_ofac
 ```
 Downloading, aggregating, ingesting and cleaning up locally - all in a few lines of bash.

--- a/ui/src/dialogs/DocumentUploadDialog/DocumentUploadForm.jsx
+++ b/ui/src/dialogs/DocumentUploadDialog/DocumentUploadForm.jsx
@@ -89,11 +89,11 @@ export class DocumentUploadForm extends PureComponent {
         <p>
           <FormattedMessage
             id="document.upload.info"
-            defaultMessage="If you need to upload a large amount of files (100+) consider {link}."
+            defaultMessage="If you need to upload a large amount of files (100+) consider {link} as command-line tool."
             values={{
               link: (
-                <a href="https://docs.aleph.occrp.org/developers/alephclient/#importing-all-files-from-a-directory">
-                  alephclient
+                <a href="https://openaleph.org/docs/user-guide/104/">
+                  openaleph
                 </a>
               ),
             }}


### PR DESCRIPTION
With OpenAlpeh the previous alephclient was renamed to openaleph as command-line tool. This let to inconsistency. Also previous links to OCCRP's docs were already broken (Error 404).

This commit reflects this change in the UI and docs.

Please note there are other mentions of alephclient that I did not change.

```bash
$ grep -r alephclient                                                                                                                                                                                                               (change-docs-alephclient✱)
CHANGELOG.md:- Ability to map entities into lists via the UI and alephclient.
CHANGELOG.md:- Aleph has two new APIs for doing a collection `reingest` and `reindex`. The existing `process` collection API is gone. `alephclient` now supports running `reingest`, `reindex`, and `delete` on a collection.
CHANGELOG.md:Be advised that any data loaded via the entity mapping mechanism will need to be re-loaded after this. It is also worth noting that at OCCRP, we have now started generating mapped data via the `followthemoney` command-line tool, and are using `alephclient` to bulk-load the resulting stream of entities into the system. This has proven to be significantly quicker than the built-in mapping process.
aleph/logic/documents.py:        # to be consistent with the behaviour of alephclient
poetry.lock:aleph = ["alephclient (>=2.6.0,<3.0.0)", "furl (>=2.1.4,<3.0.0)"]
```