### PR TITLE
chore: Update example docker-compose for pg 18

### DIFF
--- a/docs/dev-admin-guide/102/docker.md
+++ b/docs/dev-admin-guide/102/docker.md
@@ -11,7 +11,7 @@ services:
   postgres:
     image: postgres:latest
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     environment:
       POSTGRES_USER: aleph
       POSTGRES_PASSWORD: aleph


### PR DESCRIPTION
`postgres:latest` currently brings in postgres 18, which has an intentional breaking change regarding its `PGDATA` folder: https://hub.docker.com/_/postgres#pgdata. It seems sensible to suggest mounting `/var/lib/postresql` (instead of the now deprecated `/var/lib/postgresql/data`) in this guide.