### PR TITLE
Update name from oauth provider on login

### DIFF
--- a/aleph/model/role.py
+++ b/aleph/model/role.py
@@ -281,10 +281,10 @@ class Role(db.Model, IdModel, SoftDeleteModel):
 
     def update_groups(self, new_groups):
 
-        if set(new_groups) == set(self.roles): 
+        if set(new_groups) == set(self.roles):
             return
 
-        self.clear_roles()     
+        self.clear_roles()
         for group in new_groups:
             self.add_role(group)
             log.debug("User %r is member of %r", self, group)

--- a/aleph/model/role.py
+++ b/aleph/model/role.py
@@ -279,6 +279,23 @@ class Role(db.Model, IdModel, SoftDeleteModel):
     def __repr__(self):
         return "<Role(%r,%r)>" % (self.id, self.foreign_id)
 
+    def update_groups(self, new_groups):
+
+        if set(new_groups) == set(self.roles): 
+            return
+
+        self.clear_roles()     
+        for group in new_groups:
+            self.add_role(group)
+            log.debug("User %r is member of %r", self, group)
+        return
+
+    def update_name(self, name):
+        if not name or self.name == name:
+            return
+        self.name = name
+        self.touch()
+
 
 Role.members = db.relationship(
     Role,

--- a/aleph/oauth.py
+++ b/aleph/oauth.py
@@ -95,16 +95,21 @@ def handle_oauth(provider, oauth_token):
         role = Role.load_or_create(
             role_id, Role.USER, name, email=email, is_admin=is_auto_admin(email)
         )
+
     if not role.is_actor:
         return None
-    role.clear_roles()
 
+    new_group_roles = []
+    role.is_admin = is_auto_admin(email)
     for group in _get_groups(provider, oauth_token, token):
         if group == SETTINGS.OAUTH_ADMIN_GROUP:
             role.is_admin = True
             continue
         foreign_id = "group:%s" % group
         group_role = Role.load_or_create(foreign_id, Role.GROUP, group)
-        role.add_role(group_role)
-        log.debug("User %r is member of %r", role, group_role)
+        new_group_roles.append(group_role)
+    
+    role.update_groups(new_group_roles)
+    role.update_name(name or email)
+
     return role

--- a/aleph/oauth.py
+++ b/aleph/oauth.py
@@ -108,7 +108,7 @@ def handle_oauth(provider, oauth_token):
         foreign_id = "group:%s" % group
         group_role = Role.load_or_create(foreign_id, Role.GROUP, group)
         new_group_roles.append(group_role)
-    
+
     role.update_groups(new_group_roles)
     role.update_name(name or email)
 


### PR DESCRIPTION
old implementation only set the name on first login in the role table, this should do it on every login (in case the name is changed in the sso service). Also fixes a minor issue where the last_updated time stamp for users in groups was updated on every login.