### PR TITLE
Show time of email/message dates in entity references table

### DIFF
--- a/ui/src/components/Entity/EntityReferencesMode.jsx
+++ b/ui/src/components/Entity/EntityReferencesMode.jsx
@@ -101,6 +101,7 @@ class EntityReferencesMode extends React.Component {
         prop={prop}
         values={entity.getProperty(prop.name)}
         translitLookup={entity.latinized}
+        showTime={schema.isAny(['Message', 'Email'])}
       />
     );
     if (isThing && schema.caption.indexOf(prop.name) !== -1) {

--- a/ui/src/react-ftm/types/Property.tsx
+++ b/ui/src/react-ftm/types/Property.tsx
@@ -74,6 +74,7 @@ interface IPropertyValueProps extends IPropertyCommonProps {
   getEntityLink?: (entity: FTMEntity) => any;
   translitLookup?: any;
   truncate?: number;
+  showTime?: boolean;
 }
 
 const getSortValue = ({
@@ -109,6 +110,7 @@ class PropertyValue extends React.PureComponent<IPropertyValueProps> {
       value,
       truncate,
       translitLookup,
+      showTime,
     } = this.props;
     if (!value) {
       return null;
@@ -155,7 +157,7 @@ class PropertyValue extends React.PureComponent<IPropertyValueProps> {
       );
     }
     if (prop.type.name === 'date') {
-      return <Date value={value as string} />;
+      return <Date value={value as string} showTime={showTime} />;
     }
     if (prop.type.name === 'number' && !isNaN(+value)) {
       return <Numeric num={+value} />;
@@ -186,6 +188,7 @@ interface IPropertyValuesProps
   translitLookup?: any;
   truncate?: number;
   truncateItem?: number;
+  showTime?: boolean;
 }
 
 interface IPropertyValuesState {
@@ -232,6 +235,7 @@ class PropertyValues extends React.PureComponent<
       separator = ' · ',
       missing = '—',
       translitLookup,
+      showTime,
     } = this.props;
     const { truncateShowAll } = this.state;
 
@@ -246,6 +250,7 @@ class PropertyValues extends React.PureComponent<
         getEntityLink={getEntityLink}
         translitLookup={translitLookup}
         truncate={truncateItem}
+        showTime={showTime}
       />
     ));
     let content;

--- a/ui/src/viewers/EmailViewer.jsx
+++ b/ui/src/viewers/EmailViewer.jsx
@@ -13,7 +13,12 @@ class EmailViewer extends PureComponent {
     const prop = document.schema.getProperty(name);
     const values = document.getProperty(prop).map((value) => {
       let result = (
-        <Property.Value key={value.id || value} prop={prop} value={value} />
+        <Property.Value
+          key={value.id || value}
+          prop={prop}
+          value={value}
+          showTime={true}
+        />
       );
       if (entitiesProp) {
         const normValue = value.toLowerCase().trim();


### PR DESCRIPTION
Before, only the date was displayed even if the underlying property value included a time. This change also displays the time for `Message` and `Email` entities. For all other entity types (e.g., `Directorship`), the behavior is unchanged (i.e., only the date is displayed).

The solution isn't the cleanest due to the prop drilling involved, but it's the most straight forward solution and also in line with other options such as `truncate`.