### PR TITLE
Entity banners

### DIFF
--- a/aleph.env.tmpl
+++ b/aleph.env.tmpl
@@ -22,6 +22,12 @@ ALEPH_UI_URL=http://localhost:8080/
 # messages to display at the top of every page.
 # ALEPH_APP_MESSAGES_URL=https://example.org/messages.json
 
+# Entity-specific banner rules as JSON array
+# Each rule has 'condition' (JavaScript expression, harmful code is blocked) and 'message' fields
+# Optional field 'intent', defaults to warning, see https://blueprintjs.com/docs/#core/components/callout.intent
+# Condition is evaluated as JavaScript with 'entity' as the available variable, see example below (sha1sum for empty file)
+ALEPH_ENTITY_BANNER_RULES='[{"condition": "entity.getProperty && entity.getProperty(\"contentHash\") && entity.getProperty(\"contentHash\").includes(\"da39a3ee5e6b4b0d3255bfef95601890afd80709\")", "message": "The source file is empty."}]'
+
 # ALEPH_URL_SCHEME=https
 # ALEPH_FAVICON=https://search.openaleph.org/favicon.ico
 # ALEPH_LOGO=https://openaleph.org/assets/Logo/RGB/Open-Aleph-Logo-RGB-Square-Neg.svg

--- a/aleph/settings.py
+++ b/aleph/settings.py
@@ -46,6 +46,9 @@ class Settings:
         self.APP_BANNER = env.get("ALEPH_APP_BANNER")
         self.APP_MESSAGES_URL = env.get("ALEPH_APP_MESSAGES_URL", None)
 
+        # Entity-specific banner configuration as JSON
+        self.ENTITY_BANNER_RULES = self._parse_entity_banner_rules()
+
         # Force HTTPS here:
         self.FORCE_HTTPS = env.to_bool(
             "ALEPH_FORCE_HTTPS",
@@ -258,6 +261,95 @@ class Settings:
                         )
                         raise e
                     setattr(self, key[len(json_prefix) :], json_value)
+
+    def _parse_entity_banner_rules(self):
+        """Parse entity banner rules from environment variable."""
+        rules_json = env.get("ALEPH_ENTITY_BANNER_RULES")
+        if not rules_json:
+            return []
+
+        try:
+            rules = json.loads(rules_json)
+            if not isinstance(rules, list):
+                log.error("ALEPH_ENTITY_BANNER_RULES must be a JSON array")
+                return []
+
+            # List of dangerous JavaScript keywords to block
+            illegal_keywords = [
+                "eval",
+                "Function",
+                "setTimeout",
+                "setInterval",
+                "window",
+                "document",
+                "global",
+                "fetch",
+                "XMLHttpRequest",
+                "import",
+                "require",
+                "alert",
+                "confirm",
+                "prompt",
+                "localStorage",
+                "sessionStorage",
+                "__proto__",
+                "constructor",
+                "prototype",
+                "atob",
+                "btoa",
+            ]
+
+            for i, rule in enumerate(rules):
+                if (
+                    not isinstance(rule, dict)
+                    or "condition" not in rule
+                    or "message" not in rule
+                ):
+                    log.error(
+                        f"Banner rule {i} must have 'condition' and 'message' fields"
+                    )
+                    return []
+
+                message = rule["message"].strip()
+                if not message or message == "":
+                    log.error(f"Banner rule {i} has empty message.")
+
+                condition = rule["condition"]
+                if not isinstance(condition, str):
+                    log.error(f"Banner rule {i} condition must be a string")
+                    return []
+
+                for keyword in illegal_keywords:
+                    if keyword in condition:
+                        log.error(
+                            f"Banner rule {i} contains illegal keyword: {keyword}"
+                        )
+                        return []
+
+                intent = rule.get("intent", "warning")
+                if intent not in ["primary", "success", "warning", "danger", "none"]:
+                    log.warning(
+                        f"Banner rule {i} has invalid intent '{intent}', fallback to 'warning'"
+                    )
+                    intent = "warning"
+
+                icon_map = {
+                    "primary": "info-sign",
+                    "success": "tick-circle",
+                    "warning": "warning-sign",
+                    "danger": "error",
+                    "none": "info-sign",
+                }
+
+                rule["intent"] = intent
+                rule["icon"] = icon_map[intent]
+
+            log.info(f"Loaded {len(rules)} entity banner rules")
+            return rules
+
+        except JSONDecodeError as e:
+            log.error(f"Could not parse ALEPH_ENTITY_BANNER_RULES as JSON: {e}")
+            return []
 
 
 SETTINGS = Settings()

--- a/aleph/views/base_api.py
+++ b/aleph/views/base_api.py
@@ -57,6 +57,7 @@ def _metadata_locale(locale):
             "version": __version__,
             "ftm_version": ftm_version,
             "banner": SETTINGS.APP_BANNER,
+            "entity_banner_rules": SETTINGS.ENTITY_BANNER_RULES,
             "ui_uri": SETTINGS.APP_UI_URL,
             "messages_url": SETTINGS.APP_MESSAGES_URL,
             "publish": archive.can_publish,

--- a/ui/src/components/Entity/EntityHeading.jsx
+++ b/ui/src/components/Entity/EntityHeading.jsx
@@ -1,17 +1,39 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
-import { Classes } from '@blueprintjs/core';
+import { Classes, Callout, Intent } from '@blueprintjs/core';
 import c from 'classnames';
 import { Entity, Schema, RelativeTime } from 'components/common';
+import { selectMetadata } from 'selectors';
 
 import 'components/common/ItemOverview.scss';
 
 class EntityHeading extends React.PureComponent {
+  getEntityBanner(entity, bannerRules) {
+    if (!bannerRules?.length) return null;
+    
+    for (const rule of bannerRules) {
+      try {
+        // eslint-disable-next-line no-new-func
+        if (new Function('entity', `return ${rule.condition}`)(entity)) {
+          return rule;
+        }
+      } catch {
+        // Skip invalid conditions
+      }
+    }
+    
+    return null;
+  }
+
   render() {
-    const { entity, isProfile = false } = this.props;
+    const { entity, isProfile = false, metadata } = this.props;
     const lastViewedDate = entity.lastViewed
       ? new Date(parseInt(entity.lastViewed, 10))
       : Date.now();
+    
+    const bannerRules = metadata?.app?.entity_banner_rules || [];
+    const banner = this.getEntityBanner(entity, bannerRules);
 
     return (
       <>
@@ -46,9 +68,21 @@ class EntityHeading extends React.PureComponent {
             />
           </span>
         )}
+        
+        {banner && (
+          <div className="ItemOverview__heading__banner" style={{ marginTop: '12px' }}>
+            <Callout intent={Intent[banner.intent.toUpperCase()]} icon={banner.icon}>
+              {banner.message}
+            </Callout>
+          </div>
+        )}
       </>
     );
   }
 }
 
-export default EntityHeading;
+const mapStateToProps = (state) => ({
+  metadata: selectMetadata(state),
+});
+
+export default connect(mapStateToProps)(EntityHeading);


### PR DESCRIPTION
This code change introduces per-entity banners

Similar to the app-wider maintenance banner, these are controlled by env vars and set at start up. The implementation evaluates javascript with the entity as argument and shows a corresponding message. It uses the blueprintjs Callout component with default icons.

There's basic keyword filtering of the js code for malicious injections, but if someone can manipulate your production env vars you probably have other things to worry about?