### PR TITLE
Link to sender entity in entity references mode

### DIFF
--- a/ui/src/components/Entity/EntityReferencesMode.jsx
+++ b/ui/src/components/Entity/EntityReferencesMode.jsx
@@ -25,6 +25,7 @@ import EntityProperties from 'components/Entity/EntityProperties';
 import ensureArray from 'util/ensureArray';
 import { queryEntities } from 'actions/index';
 import EntityActionBar from './EntityActionBar';
+import EmailPropertyValues from 'components/common/EmailPropertyValues';
 
 const messages = defineMessages({
   no_relationships: {
@@ -154,7 +155,14 @@ class EntityReferencesMode extends React.Component {
 
   renderCell(prop, entity) {
     const { schema, isThing, isPreview } = this.props;
-    const propVal = (
+    const propVal = prop.qname === 'Email:from' ? (
+      // This is a workaround to make the email sender a link
+      <EmailPropertyValues
+        entity={entity}
+        prop={prop.name}
+        preview={!isPreview}
+      />
+    ) : (
       <Property.Values
         prop={prop}
         values={entity.getProperty(prop.name)}

--- a/ui/src/components/common/EmailPropertyValues.test.tsx
+++ b/ui/src/components/common/EmailPropertyValues.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from 'testUtils';
+import { Entity, Model, defaultModel } from '@alephdata/followthemoney';
+
+import EmailPropertyValues from './EmailPropertyValues';
+
+const model = new Model(defaultModel);
+
+it('renders default property values if no entity property is given', () => {
+  const entity = new Entity(model, {
+    id: '123',
+    schema: 'Email',
+    properties: {
+      from: ['john.doe@example.org'],
+    },
+  });
+
+  render(<EmailPropertyValues entity={entity} prop="from" />);
+
+  screen.getByText('john.doe@example.org');
+});
+
+it('merges values from entity property and default property by email address', () => {
+  const entity = new Entity(model, {
+    id: '123',
+    schema: 'Email',
+    properties: {
+      to: ['John.Doe@example.org', 'Jane Doe <Jane.Doe@example.org>'],
+      recipients: [
+        {
+          id: '456',
+          schema: 'Person',
+          properties: {
+            name: ['Jane Doe'],
+            email: ['Jane.Doe@example.org'],
+          },
+        }
+      ],
+    }
+  });
+
+  render(<EmailPropertyValues entity={entity} prop="to" />);
+
+  expect(screen.getAllByText(/John.Doe@example.org/)).toHaveLength(1);
+  screen.getByText(/John.Doe@example.org/);
+
+  expect(screen.getAllByText(/Jane.Doe@example.org/)).toHaveLength(1);
+  screen.getByRole('link', { name: /Jane Doe <Jane.Doe@example.org>/ });
+
+  expect(document.body.textContent).toEqual(
+    'John.Doe@example.org · Jane Doe <Jane.Doe@example.org>'
+  );
+});

--- a/ui/src/components/common/EmailPropertyValues.tsx
+++ b/ui/src/components/common/EmailPropertyValues.tsx
@@ -1,0 +1,92 @@
+import { Entity as FTMEntity } from '@alephdata/followthemoney';
+import { Property, Entity, Schema } from 'components/common';
+import wordList from 'util/wordList';
+
+type EmailPropertyValuesProps = {
+  entity: FTMEntity;
+  prop: string;
+  separator?: string;
+  preview?: boolean;
+};
+
+const ENTITY_PROPS: Record<string, string> = {
+  from: 'emitters',
+  to: 'recipients',
+  cc: 'recipients',
+  bcc: 'recipients',
+};
+
+export default function EmailPropertyValues({
+  entity,
+  prop,
+  separator = ' · ',
+  preview = false,
+}: EmailPropertyValuesProps) {
+  const propObj = entity.schema.getProperty(prop);
+  const entityProp = ENTITY_PROPS[prop];
+
+  const values = entity.getProperty(prop);
+  const entityValues = entityProp ? entity.getProperty(entityProp) : [];
+
+  const formattedValues = values
+    .map((value) => {
+      if (typeof value !== 'string') {
+        return null;
+      }
+
+      const normValue = value.toLowerCase().trim();
+
+      for (const entityValue of entityValues) {
+        if (!(entityValue instanceof FTMEntity)) {
+          continue;
+        }
+
+        if (!entityValue?.id) {
+          continue;
+        }
+
+        for (const email of entityValue.getProperty('email')) {
+          if (typeof email !== 'string') {
+            continue;
+          }
+
+          const normEmail = email.toLowerCase().trim();
+
+          if (normValue.includes(normEmail)) {
+            return (
+              <Entity.Link
+                key={entityValue.id}
+                entity={entityValue}
+                icon
+                preview={preview}
+              >
+                <Schema.Icon
+                  schema={entityValue.schema}
+                  className="left-icon"
+                  size={16}
+                />
+                {entityValue.getCaption() === email ? (
+                  email
+                ) : (
+                  `${entityValue.getCaption()} <${email}>`
+                )}
+              </Entity.Link>
+            );
+          }
+        }
+      }
+
+      return (
+        <Property.Value
+          key={value}
+          entity={entity}
+          prop={propObj}
+          value={value}
+          showTime={true}
+        />
+      );
+    })
+    .filter(Boolean);
+
+  return wordList(formattedValues, separator);
+};

--- a/ui/src/testUtils.tsx
+++ b/ui/src/testUtils.tsx
@@ -3,12 +3,22 @@ import {
   RenderOptions as RtlRenderOptions,
 } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
 import { FunctionComponent, ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { defaultModel } from '@alephdata/followthemoney';
+import rootReducer from 'reducers';
 import translations from 'content/translations.json';
 
 type DefaultLocale = 'en';
 type Locale = keyof typeof translations | DefaultLocale;
 type RenderOptions = RtlRenderOptions & { locale?: Locale };
+
+const store = createStore(
+  rootReducer,
+  { metadata: { model: defaultModel } },
+);
 
 function render(
   ui: ReactElement,
@@ -21,9 +31,13 @@ function render(
         : undefined;
 
     return (
-      <IntlProvider key={locale} locale={locale} messages={messages}>
-        {children}
-      </IntlProvider>
+      <Provider store={store}>
+        <MemoryRouter>
+          <IntlProvider key={locale} locale={locale} messages={messages}>
+              {children}
+          </IntlProvider>
+        </MemoryRouter>
+      </Provider>
     );
   };
 

--- a/ui/src/viewers/EmailViewer.jsx
+++ b/ui/src/viewers/EmailViewer.jsx
@@ -1,58 +1,26 @@
 import React, { PureComponent } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Classes, Pre } from '@blueprintjs/core';
-import { Schema } from 'react-ftm';
-import { Property, Skeleton, Entity } from 'components/common';
-import wordList from 'util/wordList';
+import { Skeleton } from 'components/common';
+import EmailPropertyValues from 'components/common/EmailPropertyValues';
 
 import './EmailViewer.scss';
 
 class EmailViewer extends PureComponent {
-  headerProperty(name, entitiesProp) {
+  headerProperty(name) {
     const { document } = this.props;
     const prop = document.schema.getProperty(name);
-    const values = document.getProperty(prop).map((value) => {
-      let result = (
-        <Property.Value
-          key={value.id || value}
-          prop={prop}
-          value={value}
-          showTime={true}
-        />
-      );
-      if (entitiesProp) {
-        const normValue = value.toLowerCase().trim();
-        const eprop = document.schema.getProperty(entitiesProp);
-        document.getProperty(eprop).forEach((entity) => {
-          if (!entity?.id) {
-            return;
-          }
-          entity.getProperty('email').forEach((email) => {
-            if (normValue.indexOf(email.toLowerCase().trim()) !== -1) {
-              result = (
-                <Entity.Link entity={entity} icon>
-                  <Schema.Icon
-                    schema={entity.schema}
-                    className="left-icon"
-                    size={16}
-                  />
-                  {entity.getCaption() !== email && entity.getCaption() + ' '}
-                  {'<' + email + '>'}
-                </Entity.Link>
-              );
-            }
-          });
-        });
-      }
-      return result;
-    });
-    if (values.length === 0) {
+
+    if (!document.hasProperty(name)) {
       return null;
     }
+
     return (
       <tr key={prop.qname}>
         <th>{prop.label}</th>
-        <td>{wordList(values, ', ')}</td>
+        <td>
+          <EmailPropertyValues entity={document} prop={name} separator=", " />
+        </td>
       </tr>
     );
   }
@@ -66,12 +34,12 @@ class EmailViewer extends PureComponent {
       <div className="email-header">
         <table className={Classes.HTML_TABLE}>
           <tbody>
-            {this.headerProperty('from', 'emitters')}
+            {this.headerProperty('from')}
             {this.headerProperty('date')}
             {this.headerProperty('subject')}
-            {this.headerProperty('to', 'recipients')}
-            {this.headerProperty('cc', 'recipients')}
-            {this.headerProperty('bcc', 'recipients')}
+            {this.headerProperty('to')}
+            {this.headerProperty('cc')}
+            {this.headerProperty('bcc')}
             {this.headerProperty('inReplyToEmail')}
           </tbody>
         </table>


### PR DESCRIPTION
This PR is based on #74 and I’ve set the target branch of this PR to the respective branch to make the diff easier to read. Merge #74 before and update the target branch of this PR to `main` before merging this PR.

*** 

This makes the "From" column for the "Emails sent" and "Emails received" tabs a link. This uses the same logic as the `EmailViewer` to merge the values of the `from` property (containing raw header values) with the values of the `emitters` property (containing derived `Person` entities).