### PR TITLE
Fix values of `inReplyToEmail` property not being displayed

### DIFF
--- a/ui/src/components/common/EmailPropertyValues.test.tsx
+++ b/ui/src/components/common/EmailPropertyValues.test.tsx
@@ -11,12 +11,31 @@ it('renders default property values if no entity property is given', () => {
     schema: 'Email',
     properties: {
       from: ['john.doe@example.org'],
+      inReplyToEmail: [
+        {
+          id: '456',
+          schema: 'Email',
+          properties: {
+            subject: ['Other email'],
+          },
+        },
+      ],
     },
   });
 
-  render(<EmailPropertyValues entity={entity} prop="from" />);
+  // String property
+  const { rerender } = render(
+    <EmailPropertyValues entity={entity} prop="from" />
+  );
 
   screen.getByText('john.doe@example.org');
+
+  // Entity property
+  rerender(
+    <EmailPropertyValues entity={entity} prop="inReplyToEmail" />
+  );
+
+  screen.getByRole("link", { name: /Other email/ });
 });
 
 it('merges values from entity property and default property by email address', () => {

--- a/ui/src/components/common/EmailPropertyValues.tsx
+++ b/ui/src/components/common/EmailPropertyValues.tsx
@@ -30,8 +30,19 @@ export default function EmailPropertyValues({
 
   const formattedValues = values
     .map((value) => {
+      const key = value instanceof FTMEntity ? value.id : value;
+      const formattedValue = (
+        <Property.Value
+          key={key}
+          entity={entity}
+          prop={propObj}
+          value={value}
+          showTime={true}
+        />
+      );
+
       if (typeof value !== 'string') {
-        return null;
+        return formattedValue;
       }
 
       const normValue = value.toLowerCase().trim();
@@ -76,15 +87,7 @@ export default function EmailPropertyValues({
         }
       }
 
-      return (
-        <Property.Value
-          key={value}
-          entity={entity}
-          prop={propObj}
-          value={value}
-          showTime={true}
-        />
-      );
+      return formattedValue;
     })
     .filter(Boolean);
 


### PR DESCRIPTION
The previous implementation of `EntityPropertyValues` assumed that one of the following two cases applies:

1. There is only a string property (e.g., `subject`).
2. There is a string property (e.g., `from`) and a corresponding entity property (e.g., `emitters`).

However, there's a third case where we only have an entity property (e.g., `inReplyToEmail`).