### PR TITLE
💄 Add previewMode for nearby/more like this views

### DIFF
--- a/ui/src/components/Entity/EntityMoreLikeThisMode.jsx
+++ b/ui/src/components/Entity/EntityMoreLikeThisMode.jsx
@@ -1,14 +1,18 @@
+import _ from 'lodash';
 import { Component } from 'react';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
+import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { Callout } from '@blueprintjs/core';
 import queryString from 'query-string';
+import c from 'classnames';
 
 import withRouter from 'app/withRouter';
 import { queryMoreLikeThis } from 'actions';
 import { selectMoreLikeThisResult } from 'selectors';
 import {
   ErrorSection,
+  HotkeysContainer,
   QueryInfiniteLoad,
   Entity,
   Collection,
@@ -16,15 +20,79 @@ import {
   SearchHighlight,
 } from 'components/common';
 import { entityMoreLikeThisQuery } from 'queries';
+import ensureArray from 'util/ensureArray';
+import togglePreview from 'util/togglePreview';
 
 const messages = defineMessages({
   empty: {
     id: 'entity.more_like_this.empty',
     defaultMessage: 'There are no similar entities.',
   },
+  group_label: {
+    id: 'entity.more_like_this.group_label',
+    defaultMessage: 'Similar entities preview',
+  },
+  next_preview: {
+    id: 'entity.more_like_this.next_preview',
+    defaultMessage: 'Preview next similar entity',
+  },
+  previous_preview: {
+    id: 'entity.more_like_this.previous_preview',
+    defaultMessage: 'Preview previous similar entity',
+  },
+  close_preview: {
+    id: 'entity.more_like_this.close_preview',
+    defaultMessage: 'Close preview',
+  },
 });
 
 class EntityMoreLikeThisMode extends Component {
+  constructor(props) {
+    super(props);
+    this.getCurrentPreviewIndex = this.getCurrentPreviewIndex.bind(this);
+    this.showNextPreview = this.showNextPreview.bind(this);
+    this.showPreviousPreview = this.showPreviousPreview.bind(this);
+    this.showPreview = this.showPreview.bind(this);
+    this.closePreview = this.closePreview.bind(this);
+  }
+
+  getCurrentPreviewIndex() {
+    const { previewId, results } = this.props;
+    return results.findIndex((entity) => entity.id === previewId);
+  }
+
+  showNextPreview(event) {
+    const { results } = this.props;
+    const currentSelectionIndex = this.getCurrentPreviewIndex();
+    const nextEntity = results[1 + currentSelectionIndex];
+
+    if (nextEntity && currentSelectionIndex >= 0) {
+      event.preventDefault();
+      this.showPreview(nextEntity);
+    }
+  }
+
+  showPreviousPreview(event) {
+    const { results } = this.props;
+    const currentSelectionIndex = this.getCurrentPreviewIndex();
+    const previousEntity = results[currentSelectionIndex - 1];
+
+    if (previousEntity && currentSelectionIndex >= 0) {
+      event.preventDefault();
+      this.showPreview(previousEntity);
+    }
+  }
+
+  showPreview(entity) {
+    const { navigate, location } = this.props;
+    togglePreview(navigate, location, entity);
+  }
+
+  closePreview() {
+    const { navigate, location } = this.props;
+    togglePreview(navigate, location);
+  }
+
   renderSummary() {
     const { result } = this.props;
     if (result.total === undefined || result.total === 0) {
@@ -88,11 +156,15 @@ class EntityMoreLikeThisMode extends Component {
   }
 
   renderRow(entity) {
+    const { previewId } = this.props;
     return (
       <>
-        <tr key={entity.id}>
+        <tr
+          key={entity.id}
+          className={c({ active: previewId === entity.id })}
+        >
           <td className="entity bordered">
-            <Entity.Link entity={entity} />
+            <Entity.Link entity={entity} preview />
           </td>
           <td className="collection">
             <Collection.Link collection={entity.collection} icon />
@@ -110,7 +182,7 @@ class EntityMoreLikeThisMode extends Component {
   }
 
   render() {
-    const { intl, query, result } = this.props;
+    const { intl, query, result, results } = this.props;
     const skeletonItems = [...Array(10).keys()];
 
     if (result.total === 0) {
@@ -122,23 +194,62 @@ class EntityMoreLikeThisMode extends Component {
       );
     }
 
+    const hotkeysGroupLabel = {
+      group: intl.formatMessage(messages.group_label),
+    };
+
     return (
-      <div className="EntityMoreLikeThisMode">
-        {this.renderSummary()}
-        <table className="data-table">
-          {this.renderHeader()}
-          <tbody>
-            {result.results?.map((entity) => this.renderRow(entity))}
-            {result.isPending &&
-              skeletonItems.map((idx) => this.renderSkeleton(idx))}
-          </tbody>
-        </table>
-        <QueryInfiniteLoad
-          query={query}
-          result={result}
-          fetch={this.props.queryMoreLikeThis}
-        />
-      </div>
+      <HotkeysContainer
+        hotkeys={[
+          {
+            combo: 'j',
+            label: intl.formatMessage(messages.next_preview),
+            onKeyDown: this.showNextPreview,
+            ...hotkeysGroupLabel,
+          },
+          {
+            combo: 'k',
+            label: intl.formatMessage(messages.previous_preview),
+            onKeyDown: this.showPreviousPreview,
+            ...hotkeysGroupLabel,
+          },
+          {
+            combo: 'up',
+            label: intl.formatMessage(messages.previous_preview),
+            onKeyDown: this.showPreviousPreview,
+            ...hotkeysGroupLabel,
+          },
+          {
+            combo: 'down',
+            label: intl.formatMessage(messages.next_preview),
+            onKeyDown: this.showNextPreview,
+            ...hotkeysGroupLabel,
+          },
+          {
+            combo: 'esc',
+            label: intl.formatMessage(messages.close_preview),
+            onKeyDown: this.closePreview,
+            ...hotkeysGroupLabel,
+          },
+        ]}
+      >
+        <div className="EntityMoreLikeThisMode">
+          {this.renderSummary()}
+          <table className="data-table">
+            {this.renderHeader()}
+            <tbody>
+              {results.map((entity) => this.renderRow(entity))}
+              {result.isPending &&
+                skeletonItems.map((idx) => this.renderSkeleton(idx))}
+            </tbody>
+          </table>
+          <QueryInfiniteLoad
+            query={query}
+            result={result}
+            fetch={this.props.queryMoreLikeThis}
+          />
+        </div>
+      </HotkeysContainer>
     );
   }
 }
@@ -147,15 +258,21 @@ const mapStateToProps = (state, ownProps) => {
   const { entity, location } = ownProps;
   const query = entityMoreLikeThisQuery(location, entity.id);
   const result = selectMoreLikeThisResult(state, query);
+  const results = _.uniqBy(ensureArray(result.results), 'id');
 
   const parsedHash = queryString.parse(location.hash);
 
-  return { query, result, selectedIndex: +parsedHash.selectedIndex };
+  return {
+    query,
+    result,
+    results,
+    previewId: parsedHash['preview:id'],
+    selectedIndex: +parsedHash.selectedIndex,
+  };
 };
 
-EntityMoreLikeThisMode = connect(mapStateToProps, {
-  queryMoreLikeThis,
-})(EntityMoreLikeThisMode);
-EntityMoreLikeThisMode = withRouter(EntityMoreLikeThisMode);
-EntityMoreLikeThisMode = injectIntl(EntityMoreLikeThisMode);
-export default EntityMoreLikeThisMode;
+export default compose(
+  withRouter,
+  connect(mapStateToProps, { queryMoreLikeThis }),
+  injectIntl
+)(EntityMoreLikeThisMode);

--- a/ui/src/components/Entity/EntityNearbyMode.jsx
+++ b/ui/src/components/Entity/EntityNearbyMode.jsx
@@ -13,6 +13,7 @@ import {
   Collection,
   Entity,
   ErrorSection,
+  HotkeysContainer,
   Property,
   QueryInfiniteLoad,
   Schema,
@@ -20,6 +21,7 @@ import {
 } from 'components/common';
 import EntityProperties from 'components/Entity/EntityProperties';
 import ensureArray from 'util/ensureArray';
+import togglePreview from 'util/togglePreview';
 import { queryNearby } from 'actions/index';
 import EntityActionBar from './EntityActionBar';
 
@@ -44,12 +46,70 @@ const messages = defineMessages({
     id: 'entity.references.search.placeholder_default',
     defaultMessage: 'Search entities',
   },
+  group_label: {
+    id: 'entity.nearby.group_label',
+    defaultMessage: 'Nearby entities preview',
+  },
+  next_preview: {
+    id: 'entity.nearby.next_preview',
+    defaultMessage: 'Preview next nearby entity',
+  },
+  previous_preview: {
+    id: 'entity.nearby.previous_preview',
+    defaultMessage: 'Preview previous nearby entity',
+  },
+  close_preview: {
+    id: 'entity.nearby.close_preview',
+    defaultMessage: 'Close preview',
+  },
 });
 
 class EntityNearbyMode extends React.Component {
   constructor(props) {
     super(props);
     this.onSearchSubmit = this.onSearchSubmit.bind(this);
+    this.getCurrentPreviewIndex = this.getCurrentPreviewIndex.bind(this);
+    this.showNextPreview = this.showNextPreview.bind(this);
+    this.showPreviousPreview = this.showPreviousPreview.bind(this);
+    this.showPreview = this.showPreview.bind(this);
+    this.closePreview = this.closePreview.bind(this);
+  }
+
+  getCurrentPreviewIndex() {
+    const { previewId, results } = this.props;
+    return results.findIndex((entity) => entity.id === previewId);
+  }
+
+  showNextPreview(event) {
+    const { results } = this.props;
+    const currentSelectionIndex = this.getCurrentPreviewIndex();
+    const nextEntity = results[1 + currentSelectionIndex];
+
+    if (nextEntity && currentSelectionIndex >= 0) {
+      event.preventDefault();
+      this.showPreview(nextEntity);
+    }
+  }
+
+  showPreviousPreview(event) {
+    const { results } = this.props;
+    const currentSelectionIndex = this.getCurrentPreviewIndex();
+    const previousEntity = results[currentSelectionIndex - 1];
+
+    if (previousEntity && currentSelectionIndex >= 0) {
+      event.preventDefault();
+      this.showPreview(previousEntity);
+    }
+  }
+
+  showPreview(entity) {
+    const { navigate, location } = this.props;
+    togglePreview(navigate, location, entity);
+  }
+
+  closePreview() {
+    const { navigate, location } = this.props;
+    togglePreview(navigate, location);
   }
 
   onSearchSubmit(queryText) {
@@ -81,12 +141,13 @@ class EntityNearbyMode extends React.Component {
         prop={prop}
         values={entity.getProperty(prop.name)}
         translitLookup={entity.latinized}
+        preview
       />
     );
     if (prop.name === 'full') {
       return (
         <td key={prop.name} className="entity">
-          <Entity.Link entity={entity}>
+          <Entity.Link entity={entity} preview>
             <Schema.Icon schema={entity.schema} className="left-icon" />
             {propVal}
           </Entity.Link>
@@ -101,12 +162,18 @@ class EntityNearbyMode extends React.Component {
   }
 
   renderRow(columns, entity, model) {
-    const { expandedId, hideCollection } = this.props;
+    const { expandedId, previewId, hideCollection } = this.props;
     const isExpanded = entity.id === expandedId;
     const expandIcon = isExpanded ? 'chevron-up' : 'chevron-down';
 
     const mainRow = (
-      <tr key={entity.id} className={c('nowrap', { prefix: isExpanded })}>
+      <tr
+        key={entity.id}
+        className={c('nowrap', {
+          prefix: isExpanded,
+          active: previewId === entity.id,
+        })}
+      >
         <td className="distance" style={{ width: 'auto', minWidth: '50px' }}>
           {parseFloat(entity._sort[0]).toFixed(2)} km
         </td>
@@ -163,7 +230,7 @@ class EntityNearbyMode extends React.Component {
   }
 
   render() {
-    const { intl, query, result, model, hideCollection } = this.props;
+    const { intl, query, result, results, model, hideCollection } = this.props;
     const schema = model.getSchema('Address');
 
     if (!result) {
@@ -174,69 +241,108 @@ class EntityNearbyMode extends React.Component {
         />
       );
     }
-    const results = _.uniqBy(ensureArray(result.results), 'id');
     const columns = schema.getFeaturedProperties();
     const schemaLabel = schema.plural.toLowerCase();
     const placeholder = intl.formatMessage(messages.search_placeholder, {
       schema: schemaLabel,
     });
     const skeletonItems = [...Array(15).keys()];
+    const hotkeysGroupLabel = {
+      group: intl.formatMessage(messages.group_label),
+    };
 
     return (
-      <section className="EntityReferencesTable">
-        <EntityActionBar
-          query={query}
-          onSearchSubmit={this.onSearchSubmit}
-          searchPlaceholder={placeholder}
-        ></EntityActionBar>
-        {result.total !== 0 && (
-          <>
-            <table className="data-table references-data-table">
-              <thead>
-                <tr>
-                  <th key="distance" />
-                  <th key="expand" />
-                  {columns.map((prop) => (
-                    <th key={prop.name} className={prop.type}>
-                      <Property.Name prop={prop} />
-                    </th>
-                  ))}
-                  {!hideCollection && (
-                    <th>
-                      <FormattedMessage
-                        id="xref.match_collection"
-                        defaultMessage="Dataset"
-                      />
-                    </th>
+      <HotkeysContainer
+        hotkeys={[
+          {
+            combo: 'j',
+            label: intl.formatMessage(messages.next_preview),
+            onKeyDown: this.showNextPreview,
+            ...hotkeysGroupLabel,
+          },
+          {
+            combo: 'k',
+            label: intl.formatMessage(messages.previous_preview),
+            onKeyDown: this.showPreviousPreview,
+            ...hotkeysGroupLabel,
+          },
+          {
+            combo: 'up',
+            label: intl.formatMessage(messages.previous_preview),
+            onKeyDown: this.showPreviousPreview,
+            ...hotkeysGroupLabel,
+          },
+          {
+            combo: 'down',
+            label: intl.formatMessage(messages.next_preview),
+            onKeyDown: this.showNextPreview,
+            ...hotkeysGroupLabel,
+          },
+          {
+            combo: 'esc',
+            label: intl.formatMessage(messages.close_preview),
+            onKeyDown: this.closePreview,
+            ...hotkeysGroupLabel,
+          },
+        ]}
+      >
+        <section className="EntityReferencesTable">
+          <EntityActionBar
+            query={query}
+            onSearchSubmit={this.onSearchSubmit}
+            searchPlaceholder={placeholder}
+          ></EntityActionBar>
+          {result.total !== 0 && (
+            <>
+              <table className="data-table references-data-table">
+                <thead>
+                  <tr>
+                    <th key="distance" />
+                    <th key="expand" />
+                    {columns.map((prop) => (
+                      <th key={prop.name} className={prop.type}>
+                        <Property.Name prop={prop} />
+                      </th>
+                    ))}
+                    {!hideCollection && (
+                      <th>
+                        <FormattedMessage
+                          id="xref.match_collection"
+                          defaultMessage="Dataset"
+                        />
+                      </th>
+                    )}
+                  </tr>
+                </thead>
+                <tbody>
+                  {results.map((entity) =>
+                    this.renderRow(columns, entity, model)
                   )}
-                </tr>
-              </thead>
-              <tbody>
-                {results.map((entity) =>
-                  this.renderRow(columns, entity, model)
-                )}
-                {result.isPending &&
-                  skeletonItems.map((idx) => this.renderSkeleton(columns, idx))}
-              </tbody>
-            </table>
-            <QueryInfiniteLoad
-              query={query}
-              result={result}
-              fetch={this.props.queryNearby}
+                  {result.isPending &&
+                    skeletonItems.map((idx) =>
+                      this.renderSkeleton(columns, idx)
+                    )}
+                </tbody>
+              </table>
+              <QueryInfiniteLoad
+                query={query}
+                result={result}
+                fetch={this.props.queryNearby}
+              />
+            </>
+          )}
+          {result.total === 0 && (
+            <ErrorSection
+              icon={
+                <Schema.Icon schema={schema} className="left-icon" size={60} />
+              }
+              title={intl.formatMessage(messages.no_results, {
+                schema: schemaLabel,
+              })}
             />
-          </>
-        )}
-        {result.total === 0 && (
-          <ErrorSection
-            icon={
-              <Schema.Icon schema={schema} className="left-icon" size={60} />
-            }
-            title={intl.formatMessage(messages.no_results, {
-              schema: schemaLabel,
-            })}
-          />
-        )}
-      </section>
+          )}
+        </section>
+      </HotkeysContainer>
     );
   }
 }
@@ -244,11 +350,15 @@ class EntityNearbyMode extends React.Component {
 const mapStateToProps = (state, ownProps) => {
   const { location, query } = ownProps;
   const parsedHash = queryString.parse(location.hash);
+  const result = selectNearbyResult(state, query);
+  const results = _.uniqBy(ensureArray(result.results), 'id');
   return {
     model: selectModel(state),
     parsedHash,
     expandedId: parsedHash.expand,
-    result: selectNearbyResult(state, query),
+    previewId: parsedHash['preview:id'],
+    result,
+    results,
   };
 };
 


### PR DESCRIPTION
This applies the same logic we introduced in https://github.com/openaleph/openaleph/pull/74 to `EntityMoreLikeThisMode` and `EntityNearbyMode` - opening entity references in the preview pane first.