### PR TITLE
Display search highlight snippet in entity threads mode

### DIFF
--- a/ui/src/components/Entity/EntityThreadMode.jsx
+++ b/ui/src/components/Entity/EntityThreadMode.jsx
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import withRouter from 'app/withRouter';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
@@ -14,6 +14,7 @@ import {
   ErrorSection,
   Property,
   Schema,
+  SearchHighlight,
   Skeleton,
   HotkeysContainer,
 } from 'components/common';
@@ -133,15 +134,21 @@ class EntityThreadMode extends Component {
     const { previewId } = this.props;
 
     return (
-      <tr
-        key={entity.id}
-        className={c('nowrap', {
+      <Fragment key={entity.id}>
+        <tr className={c('nowrap', {
           active: previewId === entity.id,
           current: this.props.entity.id === entity.id,
-        })}
-      >
-        {columns.map((prop) => this.renderCell(prop, entity))}
-      </tr>
+        })}>
+          {columns.map((prop) => this.renderCell(prop, entity))}
+        </tr>
+        {entity.highlight && (
+          <tr>
+            <td colSpan="100%" className="highlights">
+              <SearchHighlight highlight={entity.highlight} />
+            </td>
+          </tr>
+        )}
+      </Fragment>
     );
   }
 

--- a/ui/src/queries.js
+++ b/ui/src/queries.js
@@ -211,7 +211,7 @@ export function entityPercolateQuery(location, entityId) {
 
 export function entityThreadQuery(location, entityId) {
   const path = entityId ? `entities/${entityId}/thread` : undefined;
-  return Query.fromLocation(path, location, {}, 'thread');
+  return Query.fromLocation(path, location, { highlight: true }, 'thread');
 }
 
 export function entityNearbyQuery(location, entityId) {


### PR DESCRIPTION
Analogous to similar UI components such as the "More like this" tab.

Assuming that many emails will have an HTML part, the snippets will almost always contain HTML markup, which isn’t that helpful (see screenshot). @simonwoerpel As you mentioned you wanted to address this on the backend, I’ve made this a separate PR -- you can either merge it now, or wait until the highlights for emails are more useful.

Besides that, I think it the UI could probably be improved a bit to make the visual association between the main row and the snippet clearer. But again, that’s probably something that should be addressed consistently across the entire UI at some point?

<img width="820" height="544" alt="Screenshot 2026-04-28 at 10 12 38 PM" src="https://github.com/user-attachments/assets/58805f6f-8910-42c2-b6ce-706a1cab45cb" />


I’m ot sure if it was before or after the fork, but I remember implementing a change in ingest-file that would automatically populate `bodyText` for HTML-only emails, i.e. the `bodyText` property would be guaranteed to be present for all email entities. In case of emails, `bodyText` could be used to display more useful snippets.