### PR TITLE
🛂 (api) Restrict investigations create

### DIFF
--- a/aleph/authz.py
+++ b/aleph/authz.py
@@ -26,11 +26,20 @@ class Authz(object):
     ACCESS = "authzca"
     TOKENS = "authztk"
 
-    def __init__(self, role_id, roles, is_admin=False, token_id=None, expire=None):
+    def __init__(
+        self,
+        role_id,
+        roles,
+        is_admin=False,
+        token_id=None,
+        expire=None,
+        is_investigator=False,
+    ):
         self.id = role_id
         self.logged_in = role_id is not None
         self.roles = set(roles)
         self.is_admin = is_admin
+        self.is_investigator = is_investigator
         self.token_id = token_id
         self.expire = expire or SETTINGS.SESSION_EXPIRE
         self.session_write = not SETTINGS.MAINTENANCE and self.logged_in
@@ -126,6 +135,13 @@ class Authz(object):
             return False
         return True
 
+    def can_create_investigation(self):
+        if not self.session_write:
+            return False
+        if self.is_admin:
+            return True
+        return self.is_investigator
+
     def match(self, roles):
         """See if there's overlap in roles."""
         roles = ensure_list(roles)
@@ -175,7 +191,9 @@ class Authz(object):
         roles.add(role.id)
         roles.add(Role.load_id(Role.SYSTEM_USER))
         roles.update([g.id for g in role.roles])
-        return cls(role.id, roles, is_admin=role.is_admin)
+        return cls(
+            role.id, roles, is_admin=role.is_admin, is_investigator=role.is_investigator
+        )
 
     @classmethod
     def from_token(cls, token_id):

--- a/aleph/model/role.py
+++ b/aleph/model/role.py
@@ -73,6 +73,17 @@ class Role(db.Model, IdModel, SoftDeleteModel):
         return True
 
     @property
+    def is_investigator(self) -> bool:
+        """Role can create investigations. There is an opt-in via settings to
+        restrict this permission to a specific group, otherwise all users can
+        create their own investigations."""
+        if not self.is_actor:
+            return False
+        if SETTINGS.INVESTIGATOR_GROUP is not None:
+            return SETTINGS.INVESTIGATOR_GROUP in [r.name for r in self.roles]
+        return True
+
+    @property
     def is_alertable(self):
         if self.email is None or not self.is_actor:
             return False

--- a/aleph/model/role.py
+++ b/aleph/model/role.py
@@ -164,6 +164,7 @@ class Role(db.Model, IdModel, SoftDeleteModel):
                 "is_admin": self.is_admin,
                 "is_muted": self.is_muted,
                 "is_tester": self.is_tester,
+                "is_investigator": self.is_investigator,
                 "has_password": self.has_password,
                 # 'notified_at': self.notified_at
             }

--- a/aleph/settings.py
+++ b/aleph/settings.py
@@ -100,6 +100,9 @@ class Settings:
         self.OAUTH_TOKEN_METHOD = env.get("ALEPH_OAUTH_TOKEN_METHOD", "POST")
         self.OAUTH_ADMIN_GROUP = env.get("ALEPH_OAUTH_ADMIN_GROUP", "superuser")
 
+        # Restrict permission to create investigations to this group
+        self.INVESTIGATOR_GROUP = env.get("ALEPH_INVESTIGATOR_GROUP")
+
         # No authentication. Everyone is admin.
         self.SINGLE_USER = env.to_bool("ALEPH_SINGLE_USER")
 

--- a/aleph/tests/test_collections_api.py
+++ b/aleph/tests/test_collections_api.py
@@ -504,3 +504,27 @@ class CollectionsApiTestCase(TestCase):
         )
         res = self.client.post(bulk_url, headers=headers, data=bulk_data)
         assert res.status_code == 403, res
+
+    def test_collection_create_restricted(self):
+        """Only "investigators" can create collections"""
+
+        SETTINGS.INVESTIGATOR_GROUP = "investigator"
+
+        role, headers = self.login()
+        assert not role.is_investigator
+        assert not role.is_admin
+
+        url = "/api/2/collections"
+        data = {"foreign_id": "cannot_create_this", "label": "bar"}
+
+        res = self.client.post(url, json=data, headers=headers)
+        assert res.status_code == 403
+
+        SETTINGS.INVESTIGATOR_GROUP = None
+
+        # if no group set, everyone is allowed
+        role, headers = self.login()
+        assert role.is_investigator
+        assert not role.is_admin
+        res = self.client.post(url, json=data, headers=headers)
+        assert res.status_code == 200

--- a/aleph/views/collections_api.py
+++ b/aleph/views/collections_api.py
@@ -84,7 +84,7 @@ def create():
               schema:
                 $ref: '#/components/schemas/Collection'
     """
-    require(request.authz.session_write)
+    require(request.authz.can_create_investigation())
     data = parse_request("CollectionCreate")
     sync = get_flag("sync", True)
     try:

--- a/ui/src/screens/InvestigationIndexScreen/InvestigationIndexScreen.jsx
+++ b/ui/src/screens/InvestigationIndexScreen/InvestigationIndexScreen.jsx
@@ -9,6 +9,7 @@ import Dashboard from 'components/Dashboard/Dashboard';
 import CollectionIndex from 'components/CollectionIndex/CollectionIndex';
 import InvestigationCreateButton from 'components/Toolbar/InvestigationCreateButton';
 import { investigationsQuery } from 'queries';
+import { selectInvestigator } from 'selectors';
 
 const messages = defineMessages({
   title: {
@@ -31,11 +32,16 @@ const messages = defineMessages({
     id: 'cases.no_results',
     defaultMessage: 'No investigations were found matching this query.',
   },
+  not_investigator: {
+    id: 'cases.not_allowed',
+    defaultMessage:
+      'You are not authorized to create new investigations. Contact your platform administrator.',
+  },
 });
 
 export class InvestigationIndexScreen extends Component {
   render() {
-    const { query, intl } = this.props;
+    const { query, intl, canCreate } = this.props;
     return (
       <Screen
         className="InvestigationIndexScreen"
@@ -53,12 +59,18 @@ export class InvestigationIndexScreen extends Component {
                 defaultMessage="Investigations let you upload and share documents and data which belong to a particular story. You can upload PDFs, email archives or spreadsheets, and they will be made easy to search and browse."
               />
             </p>
-            <div className="Dashboard__actions">
-              <InvestigationCreateButton
-                icon="briefcase"
-                text={intl.formatMessage(messages.create)}
-              />
-            </div>
+            {canCreate ? (
+              <div className="Dashboard__actions">
+                <InvestigationCreateButton
+                  icon="briefcase"
+                  text={intl.formatMessage(messages.create)}
+                />
+              </div>
+            ) : (
+              <p className="Dashboard__subheading">
+                {intl.formatMessage(messages.not_investigator)}
+              </p>
+            )}
           </div>
           <CollectionIndex
             query={query}
@@ -75,7 +87,10 @@ export class InvestigationIndexScreen extends Component {
 
 const mapStateToProps = (state, ownProps) => {
   const { location } = ownProps;
-  return { query: investigationsQuery(location) };
+  return {
+    query: investigationsQuery(location),
+    canCreate: selectInvestigator(state),
+  };
 };
 
 export default compose(

--- a/ui/src/selectors.js
+++ b/ui/src/selectors.js
@@ -195,6 +195,12 @@ export function selectTester(state) {
   return role.is_tester || false;
 }
 
+export function selectInvestigator(state) {
+  const role = selectCurrentRole(state);
+  /* eslint-disable camelcase */
+  return role.is_investigator || false;
+}
+
 export function selectAdmin(state) {
   const role = selectCurrentRole(state);
   /* eslint-disable camelcase */


### PR DESCRIPTION
This is an opt-in to restrict the permission to create a collection ("investigation") for non-admin users to a specific group. If not set, the default behaviour (anyone can create).