### PR TITLE
freeze header row in table explore

### DIFF
--- a/ui/src/viewers/CSVExplorer.scss
+++ b/ui/src/viewers/CSVExplorer.scss
@@ -181,6 +181,9 @@
       white-space: nowrap;
       cursor: pointer;
       user-select: none;
+      position: sticky;
+      top: 0;
+      z-index: 1;
 
       &:hover {
         background: #ebf1f5;


### PR DESCRIPTION
makes column headers stick to the top in table explore view