### PR TITLE
feat(threads): show the thread view for Message entities, not just Email

### DIFF
--- a/aleph/search/query.py
+++ b/aleph/search/query.py
@@ -173,7 +173,10 @@ class MessageThreadQuery:
     SCHEMATA = ("Email", "Message")
     # FIXME this needs a bit rethink about the ?dehydrate=True param for
     # EntityReferenceMode and similar UI logic in general
-    INCLUDES = {"Email": ["sender", "emitters", "recipients"]}
+    INCLUDES = {
+        "Email": ["sender", "emitters", "recipients"],
+        "Message": ["sender", "recipients"],
+    }
 
     # Hard backend caps — callers can request a lower limit via the parser
     # but cannot exceed these.

--- a/ui/src/components/Entity/EntityContextLoader.jsx
+++ b/ui/src/components/Entity/EntityContextLoader.jsx
@@ -87,7 +87,8 @@ class EntityContextLoader extends PureComponent {
     }
 
     const { threadQuery, threadResult } = this.props;
-    const showThread = entity?.schema?.isA("Email");
+    const showThread =
+      entity?.schema?.isA("Email") || entity?.schema?.isA("Message");
     if (showThread && threadResult.shouldLoad) {
       this.props.queryThread({ query: threadQuery });
     }

--- a/ui/src/components/Entity/EntityThreadMode.jsx
+++ b/ui/src/components/Entity/EntityThreadMode.jsx
@@ -4,14 +4,13 @@ import withRouter from 'app/withRouter';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import c from 'classnames';
 import queryString from 'query-string';
-import { Tag } from '@blueprintjs/core';
+import { Callout, Tag } from '@blueprintjs/core';
 import { entityThreadQuery } from 'queries';
 import { selectThreadResult } from 'selectors';
 import togglePreview from 'util/togglePreview';
 import EmailPropertyValues from 'components/common/EmailPropertyValues';
 import {
   Entity,
-  ErrorSection,
   Property,
   Schema,
   SearchHighlight,
@@ -54,25 +53,9 @@ class EntityThreadMode extends Component {
     const columns = schema.getFeaturedProperties();
     const skeletonItems = [...Array(15).keys()];
 
-    if (result.total_type === "gte") {
-      return (
-        <ErrorSection
-          title={
-            <FormattedMessage
-              id="entity.thread.too_long.title"
-              defaultMessage="This thread is too long."
-            />
-          }
-          description={
-            <FormattedMessage
-              id="entity.thread.too_long.description"
-              defaultMessage="This thread can’t be displayed because it contains more than {limit} messages."
-              values={{ limit: result.limit }}
-            />
-          }
-        />
-      );
-    }
+    // A truncated thread (total_type "gte") is still worth showing:
+    // render the window we received with a notice, instead of refusing.
+    const truncated = result.total_type === 'gte';
 
     return (
       <HotkeysContainer
@@ -110,6 +93,15 @@ class EntityThreadMode extends Component {
         ]}
       >
         <div className="EntityThreadMode">
+          {truncated && (
+            <Callout intent="warning" icon="warning-sign">
+              <FormattedMessage
+                id="entity.thread.truncated"
+                defaultMessage="This thread is longer than what can be displayed — showing {count} messages."
+                values={{ count: result.results?.length || result.limit }}
+              />
+            </Callout>
+          )}
           <table className="data-table references-data-table">
             <thead>
               <tr>

--- a/ui/src/components/Entity/EntityViews.jsx
+++ b/ui/src/components/Entity/EntityViews.jsx
@@ -296,13 +296,16 @@ class EntityViews extends React.Component {
           {!references.total && references.isPending && (
             <Tab id="loading" title={<TextLoading loading={true} />} />
           )}
-          {entity.schema.isA("Email") && (
+          {(entity.schema.isA("Email") || entity.schema.isA("Message")) && (
             <Tab
               id="thread"
               disabled={thread.total === 0}
               title={
                 <TextLoading loading={thread.isPending}>
-                  <Schema.Icon schema="Email" className="left-icon" />
+                  <Schema.Icon
+                    schema={entity.schema.name}
+                    className="left-icon"
+                  />
                   <FormattedMessage
                     id="entity.info.thread"
                     defaultMessage="Thread"

--- a/ui/src/queries.js
+++ b/ui/src/queries.js
@@ -211,7 +211,11 @@ export function entityPercolateQuery(location, entityId) {
 
 export function entityThreadQuery(location, entityId) {
   const path = entityId ? `entities/${entityId}/thread` : undefined;
-  return Query.fromLocation(path, location, { highlight: true }, 'thread');
+  // Request up to the backend's MAX_RESULTS (200) instead of the default
+  // page size: chat-style Message threads routinely exceed 30 entries.
+  return Query.fromLocation(path, location, { highlight: true }, 'thread').limit(
+    200
+  );
 }
 
 export function entityNearbyQuery(location, entityId) {


### PR DESCRIPTION
**What** — The message-threads feature (#83, #88, #92) reconstructs a conversation from the reply chain. The backend `MessageThreadQuery` already declares `SCHEMATA = ("Email", "Message")`, but the UI only loaded and rendered the Thread tab for `Email`. So chat/iMessage-style `Message` entities with a valid reply chain (`messageId` + `inReplyTo`) never surfaced their thread. And once they do, chat-length conversations immediately hit the display caps: any truncated thread response (`total_type: "gte"`) was rendered as a bare "This thread is too long" error, discarding the message window the backend had already returned.

**Changes**
- *ui:* widen the thread gate in `EntityContextLoader` + `EntityViews` from `isA("Email")` to `isA("Email") || isA("Message")`; use the entity's own schema icon in the tab instead of a hardcoded Email icon.
- *ui:* `EntityThreadMode` now renders truncated threads — the returned window plus a warning callout ("showing {count} messages") — instead of refusing outright; `entityThreadQuery` requests up to the backend's `MAX_RESULTS` (200) instead of the default page size (30).
- *backend:* add a `Message` entry to `MessageThreadQuery.INCLUDES` so thread previews carry `sender`/`recipients` for messages too.

**Testing** — Validated against a collection of iMessage-style `Message` conversations (3–3,356 messages, reply chains as `messageId`/`inReplyTo`): the Thread tab renders complete conversations up to 200 messages identically to email threads, and longer ones show the first 200 chronologically with the truncation notice instead of a blank error. See the discussion comment below for chat-scale findings about the walker itself (linear-chain depth behavior), which this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)