### PR TITLE
Quality of life fixes for Table Explorer

### DIFF
--- a/ui/src/util/sqlWorker.js
+++ b/ui/src/util/sqlWorker.js
@@ -16,17 +16,26 @@ const FLOAT = /^\s*-?(\d+\.?|\.\d+|\d+\.\d+)([eE][-+]?\d+)?\s*$/;
 const MAX_FLOAT = Math.pow(2, 53);
 const EURO_NUMBER = /^[+-]?(?:\d{1,3}(?:\.\d{3})+|\d+)(?:,\d+)?$/;
 
-function typeValue(value) {
-  const trimmed = value.trim();
-  if (trimmed === '') return null;
+
+function parseNumber(trimmed) {
   const normalized = EURO_NUMBER.test(trimmed)
     ? trimmed.replace(/\./g, '').replace(',', '.')
-    : value;
+    : trimmed;
   if (FLOAT.test(normalized)) {
     const num = parseFloat(normalized);
     if (num > -MAX_FLOAT && num < MAX_FLOAT) return num;
   }
-  return normalized;
+  return undefined;
+}
+
+function typeValue(value) {
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+  const num = parseNumber(trimmed);
+  if (num !== undefined) return num;
+  return EURO_NUMBER.test(trimmed)
+    ? trimmed.replace(/\./g, '').replace(',', '.')
+    : value;
 }
 
 async function init(csvUrl, skiprows, genericHeaders, separator) {
@@ -106,9 +115,24 @@ function query({ search, filters, sortCol, sortDir, page, pageSize }) {
     const idx = columns.indexOf(displayCol);
     if (idx === -1) continue;
     const alias = colAliases[idx];
+    const num = parseNumber(val.trim());
     if (op === 'equals') {
-      whereClauses.push(`${alias} = ?`);
-      params.push(val);
+      if (num !== undefined) {
+        whereClauses.push(`(${alias} = ? OR ${alias} = ?)`);
+        params.push(val, num);
+      } else {
+        whereClauses.push(`${alias} = ?`);
+        params.push(val);
+      }
+    } else if (op === 'lt' || op === 'gt') {
+      const cmp = op === 'lt' ? '<' : '>';
+      if (num !== undefined) {
+        whereClauses.push(`(typeof(${alias}) IN ('integer', 'real') AND ${alias} ${cmp} ?)`);
+        params.push(num);
+      } else {
+        whereClauses.push(`(typeof(${alias}) = 'text' AND ${alias} ${cmp} ?)`);
+        params.push(val);
+      }
     } else if (op === 'starts') {
       whereClauses.push(`${alias} LIKE ?`);
       params.push(`${val}%`);
@@ -118,12 +142,6 @@ function query({ search, filters, sortCol, sortDir, page, pageSize }) {
     } else if (op === 'not_contains') {
       whereClauses.push(`${alias} NOT LIKE ?`);
       params.push(`%${val}%`);
-    } else if (op === 'lt') {
-      whereClauses.push(`${alias} < ?`);
-      params.push(parseFloat(val) || 0);
-    } else if (op === 'gt') {
-      whereClauses.push(`${alias} > ?`);
-      params.push(parseFloat(val) || 0);
     } else {
       whereClauses.push(`${alias} LIKE ?`);
       params.push(`%${val}%`);

--- a/ui/src/util/sqlWorker.js
+++ b/ui/src/util/sqlWorker.js
@@ -41,6 +41,7 @@ async function init(csvUrl, skiprows, genericHeaders, separator) {
 async function processCSV() {
   const { skiprows, genericHeaders, separator } = currentSettings;
   const SQL = await initSqlJs({ locateFile: () => '/sql-wasm.wasm' });
+  if (db) db.close();
   db = new SQL.Database();
 
   const lines = csvText.split(/\r?\n/);

--- a/ui/src/viewers/CSVExplorer.jsx
+++ b/ui/src/viewers/CSVExplorer.jsx
@@ -77,7 +77,18 @@ class CSVExplorer extends Component {
       if (type === 'ready') {
         const { columns, total, delimiter } = event.data;
         const separatorUpdate = this.state.separator === 'auto' ? { separator: delimiter } : {};
-        this.setState({ columns, total, page: 1, loading: false, ...separatorUpdate }, () => {
+        this.setState({
+          columns,
+          total,
+          sortCol: null,
+          filterCol: '',
+          filterOp: 'contains',
+          filterVal: '',
+          filters: {},
+          page: 1,
+          loading: false,
+          ...separatorUpdate,
+        }, () => {
           this.runQuery();
         });
       } else if (type === 'results') {

--- a/ui/src/viewers/CSVExplorer.jsx
+++ b/ui/src/viewers/CSVExplorer.jsx
@@ -177,7 +177,7 @@ class CSVExplorer extends Component {
               <option value=",">,</option>
               <option value=";">;</option>
               <option value=":">:</option>
-              <option value="\t">tab</option>
+              <option value={'\t'}>tab</option>
               <option value="|">|</option>
             </select>
             <span className="bp4-icon bp4-icon-double-caret-vertical" />
@@ -198,7 +198,7 @@ class CSVExplorer extends Component {
   renderToolbar() {
     const { intl } = this.props;
     const { search, total, skiprows } = this.state;
-    const delimiter = this.state.separator || "auto";
+    const delimiter = this.state.separator === '\t' ? 'tab' : this.state.separator || "auto";
 
     return (
       <div className="CSVExplorer__toolbar">

--- a/ui/src/viewers/CSVExplorer.jsx
+++ b/ui/src/viewers/CSVExplorer.jsx
@@ -48,6 +48,7 @@ class CSVExplorer extends Component {
       filterVal: '',
     };
     this.worker = null;
+    this.timer = null;
     this.onSearch = this.onSearch.bind(this);
     this.onSort = this.onSort.bind(this);
     this.onPage = this.onPage.bind(this);
@@ -59,6 +60,7 @@ class CSVExplorer extends Component {
   }
 
   componentWillUnmount() {
+    clearTimeout(this.timer);
     if (this.worker) this.worker.terminate();
   }
 
@@ -128,7 +130,9 @@ class CSVExplorer extends Component {
   }
 
   onSearch(e) {
-    this.setState({ search: e.target.value, page: 1 }, () => this.runQuery());
+    this.setState({ search: e.target.value, page: 1 });
+    clearTimeout(this.timer);
+    this.timer = setTimeout(() => this.runQuery(), 350);
   }
 
   onSort(col) {

--- a/ui/src/viewers/CSVExplorer.jsx
+++ b/ui/src/viewers/CSVExplorer.jsx
@@ -24,6 +24,10 @@ const messages = defineMessages({
     id: 'document.csv_explorer.filter_apply',
     defaultMessage: 'Apply',
   },
+  retry: {
+    id: 'document.csv_explorer.retry',
+    defaultMessage: 'Retry',
+  },
 });
 
 class CSVExplorer extends Component {
@@ -117,6 +121,7 @@ class CSVExplorer extends Component {
   }
 
   runQuery() {
+    if (!this.worker || this.state.error) return;
     const { search, filters, sortCol, sortDir, page } = this.state;
     this.worker.postMessage({
       type: 'query',
@@ -164,6 +169,12 @@ class CSVExplorer extends Component {
   }
 
   onSettingsChange(patch) {
+    // in the error state the worker may be dead: only stage the settings,
+    // the retry action re-inits from state
+    if (this.state.error) {
+      this.setState(patch);
+      return;
+    }
     this.setState({ ...patch, loading: true }, () => {
       if (this.worker) { this.worker.postMessage({ type: 'updateSettings', ...patch }); }});
   }
@@ -305,18 +316,26 @@ class CSVExplorer extends Component {
     const { loading, error, columns, rows, sortCol, sortDir, page, total } = this.state;
     const totalPages = Math.ceil(total / PAGE_SIZE);
 
-    if (error) {
-      return <NonIdealState icon="error" title="Error" description={error} />;
-    }
-
     return (
       <div className="CSVExplorer__table-container">
         {this.renderToolbar()}
-        {columns.length > 0 && this.renderFilterBar()}
-        {loading && (
+        {error && (
+          <NonIdealState
+            icon="error"
+            title="Error"
+            description={error}
+            action={
+              <Button intent="primary" onClick={() => this.initWorker()}>
+                <FormattedMessage {...messages.retry} />
+              </Button>
+            }
+          />
+        )}
+        {!error && columns.length > 0 && this.renderFilterBar()}
+        {!error && loading && (
           <NonIdealState icon={<Spinner />} title="Loading…" />
         )}
-        {!loading && columns.length > 0 && (
+        {!error && !loading && columns.length > 0 && (
           <>
             <div className="CSVExplorer__scroll">
               <table className="CSVExplorer__table">

--- a/ui/src/viewers/CSVExplorer.jsx
+++ b/ui/src/viewers/CSVExplorer.jsx
@@ -77,7 +77,7 @@ class CSVExplorer extends Component {
       if (type === 'ready') {
         const { columns, total, delimiter } = event.data;
         const separatorUpdate = this.state.separator === 'auto' ? { separator: delimiter } : {};
-        this.setState({ columns, total, loading: false, ...separatorUpdate }, () => {
+        this.setState({ columns, total, page: 1, loading: false, ...separatorUpdate }, () => {
           this.runQuery();
         });
       } else if (type === 'results') {

--- a/ui/src/viewers/CSVExplorer.jsx
+++ b/ui/src/viewers/CSVExplorer.jsx
@@ -3,7 +3,7 @@
 // sort and pagination queries against it without any server round-trips.
 // Requires public/sql-wasm.wasm (copied from node_modules/sql.js/dist/).
 import { Component } from 'react';
-import { Tooltip, Button, Spinner, NonIdealState, Position } from '@blueprintjs/core';
+import { Tooltip, Button, Spinner, NonIdealState, Position, Menu, MenuItem, MenuDivider } from '@blueprintjs/core';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 
 import './CSVExplorer.scss';
@@ -28,6 +28,18 @@ const messages = defineMessages({
     id: 'document.csv_explorer.retry',
     defaultMessage: 'Retry',
   },
+  sort_asc: {
+    id: 'document.csv_explorer.sort_asc',
+    defaultMessage: 'Sort asc.',
+  },
+  sort_desc: {
+    id: 'document.csv_explorer.sort_desc',
+    defaultMessage: 'Sort desc.',
+  },
+  hide_column: {
+    id: 'document.csv_explorer.hide_column',
+    defaultMessage: 'Hide',
+  },
 });
 
 class CSVExplorer extends Component {
@@ -50,11 +62,11 @@ class CSVExplorer extends Component {
       filterCol: '',
       filterOp: 'contains',
       filterVal: '',
+      hiddenCols: new Set(),
     };
     this.worker = null;
     this.timer = null;
     this.onSearch = this.onSearch.bind(this);
-    this.onSort = this.onSort.bind(this);
     this.onPage = this.onPage.bind(this);
     this.onApplyFilter = this.onApplyFilter.bind(this);
   }
@@ -92,6 +104,7 @@ class CSVExplorer extends Component {
           filterVal: '',
           filters: {},
           page: 1,
+          hiddenCols: new Set(),
           loading: false,
           ...separatorUpdate,
         }, () => {
@@ -140,16 +153,20 @@ class CSVExplorer extends Component {
     this.timer = setTimeout(() => this.runQuery(), 350);
   }
 
-  onSort(col) {
-    this.setState(({ sortCol, sortDir }) => ({
-      sortCol: col,
-      sortDir: sortCol === col && sortDir === 'ASC' ? 'DESC' : 'ASC',
-      page: 1,
-    }), () => this.runQuery());
+  onSortDir(col, dir) {
+    this.setState({ sortCol: col, sortDir: dir, page: 1 }, () => this.runQuery());
   }
 
   onPage(page) {
     this.setState({ page }, () => this.runQuery());
+  }
+
+  onHideCol(i) {
+    this.setState(({ hiddenCols }) => {
+      const next = new Set(hiddenCols);
+      next.add(i);
+      return { hiddenCols: next };
+    });
   }
 
   onApplyFilter() {
@@ -223,7 +240,7 @@ class CSVExplorer extends Component {
 
   renderToolbar() {
     const { intl } = this.props;
-    const { search, total, skiprows } = this.state;
+    const { search, total, skiprows, hiddenCols } = this.state;
     const delimiter = this.state.separator === '\t' ? 'tab' : this.state.separator || "auto";
 
     return (
@@ -237,6 +254,15 @@ class CSVExplorer extends Component {
         />
         <span className="CSVExplorer__meta">
           Total: {total.toLocaleString()} • Skipped: {skiprows.toLocaleString()} • Separator: "{delimiter}"
+          {hiddenCols.size > 0 && (
+            <>
+              {' '}• {hiddenCols.size} hidden (
+              <button
+                className="CSVExplorer__link-button"
+                onClick={() => this.setState({ hiddenCols: new Set() })}
+              >show all</button>)
+            </>
+          )}
       </span>
         <Popover2
           content={this.renderSettings()}
@@ -313,7 +339,8 @@ class CSVExplorer extends Component {
   }
 
   render() {
-    const { loading, error, columns, rows, sortCol, sortDir, page, total } = this.state;
+    const { intl } = this.props;
+    const { loading, error, columns, rows, sortCol, sortDir, page, total, hiddenCols } = this.state;
     const totalPages = Math.ceil(total / PAGE_SIZE);
 
     return (
@@ -341,14 +368,42 @@ class CSVExplorer extends Component {
               <table className="CSVExplorer__table">
                 <thead>
                   <tr>
-                    {columns.map((col, i) => (
+                    {columns.map((col, i) => !hiddenCols.has(i) && (
                       <th
                         key={i}
-                        onClick={() => this.onSort(col)}
                         className={sortCol === col ? `sorted-${sortDir.toLowerCase()}` : ''}
                       >
-                        {col}
-                        {sortCol === col && (sortDir === 'ASC' ? ' ↑' : ' ↓')}
+                        <Popover2
+                          content={
+                            <Menu className="CSVExplorer__col-menu">
+                              <MenuItem
+                                icon="sort-asc"
+                                text={intl.formatMessage(messages.sort_asc)}
+                                active={sortCol === col && sortDir === 'ASC'}
+                                onClick={() => this.onSortDir(col, 'ASC')}
+                              />
+                              <MenuItem
+                                icon="sort-desc"
+                                text={intl.formatMessage(messages.sort_desc)}
+                                active={sortCol === col && sortDir === 'DESC'}
+                                onClick={() => this.onSortDir(col, 'DESC')}
+                              />
+                              <MenuDivider />
+                              <MenuItem
+                                icon="eye-off"
+                                text={intl.formatMessage(messages.hide_column)}
+                                onClick={() => this.onHideCol(i)}
+                              />
+                            </Menu>
+                          }
+                          position={Position.BOTTOM}
+                          minimal
+                        >
+                          <span className="CSVExplorer__th-label">
+                            {col}
+                            {sortCol === col && (sortDir === 'ASC' ? ' ↑' : ' ↓')}
+                          </span>
+                        </Popover2>
                       </th>
                     ))}
                   </tr>
@@ -356,7 +411,7 @@ class CSVExplorer extends Component {
                 <tbody>
                   {rows.map((row, i) => (
                     <tr key={i}>
-                      {row.map((cell, j) => (
+                      {row.map((cell, j) => !hiddenCols.has(j) && (
                         <td key={j}>{cell}</td>
                       ))}
                     </tr>

--- a/ui/src/viewers/CSVExplorer.jsx
+++ b/ui/src/viewers/CSVExplorer.jsx
@@ -160,7 +160,7 @@ class CSVExplorer extends Component {
   }
 
   onSettingsChange(patch) {
-    this.setState(patch, () => {
+    this.setState({ ...patch, loading: true }, () => {
       if (this.worker) { this.worker.postMessage({ type: 'updateSettings', ...patch }); }});
   }
 

--- a/ui/src/viewers/CSVExplorer.scss
+++ b/ui/src/viewers/CSVExplorer.scss
@@ -193,6 +193,10 @@
       &.sorted-desc {
         background: #ebf1f5;
       }
+
+      .bp4-popover2-target {
+        display: block;
+      }
     }
 
     tbody td {
@@ -208,6 +212,24 @@
     tbody tr:hover td {
       background: #f5f8fa;
     }
+  }
+
+  &__link-button {
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    color: #106ba3;
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  // rendered in a portal outside the component tree, hence a flat selector
+  &__col-menu.bp4-menu {
+    min-width: 130px;
   }
 
   &__pagination {


### PR DESCRIPTION
Follow-up to #110 , based on that branch.

- Fix the `tab` separator option (earlier version sent literal \t)
- database was never closed on settings change, now fixed
- Reset view state (filters, sort, pending filter form, page) on re-parse to avoid stale filters
- Make comparisons type-aware ( `=` matches both text and float,  `</>` compares float against float, str against str)
- Show loading animations on settings updates
- Debounce the search input instead of firing on each keystroke
- Add retry button on error, show settings menu too
- Add column hiding with reset in the toolbar, clicking a header shows a small menu to sort or hide