### PR TITLE
Specify Docker image arch for ingest-file

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -40,6 +40,8 @@ services:
 
   ingest:
     image: ghcr.io/openaleph/ingest-file:${ALEPH_TAG:-latest}
+    # ingest-file is currently published only for AMD64.
+    platform: linux/amd64
     command: procrastinate worker -q ingest
     tmpfs:
       - /tmp:mode=777

--- a/docs/dev-admin-guide/102/docker.md
+++ b/docs/dev-admin-guide/102/docker.md
@@ -32,6 +32,8 @@ services:
 
   ingest:
     image: ghcr.io/openaleph/ingest-file:latest
+    # ingest-file is currently published only for AMD64.
+    platform: linux/amd64
     command: procrastinate worker -q ingest
     tmpfs:
       - /tmp:mode=777


### PR DESCRIPTION
This makes the setup instructions work out-of-the-box on mac OS. Otherwise one would get ```no matching manifest for linux/arm64/v8 in the manifest list entries```