### PR TITLE
Single command to start a local environment from scratch

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Discover how to install, use, and contribute to OpenAleph through our [documenta
 
 OpenAleph can be deployed locally with Docker, for testing purposes:
 
+Run `./contrib/start-local.sh` to start a single-user local instance with a generated secret key. Or configure the stack manually:
+
 1. Run `cp aleph.env.tmpl aleph.env` and then edit `aleph.env`. Assign a value to `ALEPH_SECRET_KEY` — the Docker images already default to the bundled postgres, elasticsearch and redis services; see the [Docker setup guide](https://openaleph.org/docs/dev-admin-guide/102/docker/) for more configuration options. You can also set `ALEPH_SINGLE_USER=true` or create an admin user following the instructions [in the documentation](https://openaleph.org/docs/dev-admin-guide/104/setup/).
 2. Run `docker compose -f docker-compose.example.yml up -d` to start the full stack with prebuilt images (or `make up` to run it in the foreground).
 3. Once Elasticsearch reports a green health status in the logs, run `docker compose -f docker-compose.example.yml run --rm worker aleph upgrade` to initialize the database and search index.

--- a/contrib/start-local.sh
+++ b/contrib/start-local.sh
@@ -8,36 +8,37 @@ COMPOSE_FILE="$ROOT_DIR/docker-compose.example.yml"
 ENV_FILE="$ROOT_DIR/aleph.env"
 
 if ! command -v docker >/dev/null 2>&1; then
-    printf '%s\n' 'Docker is required. Install Docker and try again.' >&2
-    exit 1
+  printf '%s\n' 'Docker is required. Install Docker and try again.' >&2
+  exit 1
 fi
 
 if ! docker compose version >/dev/null 2>&1; then
-    printf '%s\n' 'Docker Compose v2 is required. Install it and try again.' >&2
-    exit 1
+  printf '%s\n' 'Docker Compose v2 is required. Install it and try again.' >&2
+  exit 1
 fi
 
 if ! command -v openssl >/dev/null 2>&1 || ! command -v curl >/dev/null 2>&1; then
-    printf '%s\n' 'openssl and curl are required. Install them and try again.' >&2
-    exit 1
+  printf '%s\n' 'openssl and curl are required. Install them and try again.' >&2
+  exit 1
 fi
 
 if [ ! -f "$ENV_FILE" ]; then
-    secret_key=$(openssl rand -hex 32)
-    (
-        umask 077
-        sed \
-            -e "s/^ALEPH_SECRET_KEY=.*/ALEPH_SECRET_KEY=$secret_key/" \
-            -e 's/^ALEPH_SINGLE_USER=.*/ALEPH_SINGLE_USER=true/' \
-            "$ROOT_DIR/aleph.env.tmpl" >"$ENV_FILE"
-    )
-    printf '%s\n' 'Created aleph.env with a generated secret key and single-user mode enabled.'
+  secret_key=$(openssl rand -hex 32)
+  (
+    umask 077
+    sed \
+      -e "s/^ALEPH_SECRET_KEY=.*/ALEPH_SECRET_KEY=$secret_key/" \
+      -e 's/^ALEPH_SINGLE_USER=.*/ALEPH_SINGLE_USER=true/' \
+      -e 's,^# FTM_FRAGMENTS_URI=postgresql://aleph:aleph@postgres/aleph,FTM_FRAGMENTS_URI=postgresql://aleph:aleph@postgres/aleph,' \
+      "$ROOT_DIR/aleph.env.tmpl" >"$ENV_FILE"
+  )
+  printf '%s\n' 'Created aleph.env with a generated secret key, single-user mode enabled and the default fragments db url.'
 else
-    printf '%s\n' 'Using existing aleph.env without changes.'
+  printf '%s\n' 'Using existing aleph.env without changes.'
 fi
 
 compose() {
-    docker compose -f "$COMPOSE_FILE" "$@"
+  docker compose -f "$COMPOSE_FILE" "$@"
 }
 
 printf '%s\n' 'Starting OpenAleph services...'
@@ -46,15 +47,15 @@ compose up -d
 printf '%s\n' 'Waiting for Elasticsearch to become green...'
 attempt=0
 until compose exec -T elasticsearch curl -fsS \
-    'http://localhost:9200/_cluster/health?wait_for_status=green&timeout=1s' \
-    >/dev/null 2>&1; do
-    attempt=$((attempt + 1))
-    if [ "$attempt" -ge 120 ]; then
-        printf '%s\n' 'Elasticsearch did not become green within 10 minutes.' >&2
-        printf '%s\n' 'Inspect the service with: docker compose -f docker-compose.example.yml logs elasticsearch' >&2
-        exit 1
-    fi
-    sleep 5
+  'http://localhost:9200/_cluster/health?wait_for_status=green&timeout=1s' \
+  >/dev/null 2>&1; do
+  attempt=$((attempt + 1))
+  if [ "$attempt" -ge 120 ]; then
+    printf '%s\n' 'Elasticsearch did not become green within 10 minutes.' >&2
+    printf '%s\n' 'Inspect the service with: docker compose -f docker-compose.example.yml logs elasticsearch' >&2
+    exit 1
+  fi
+  sleep 5
 done
 
 printf '%s\n' 'Initializing the database and search index...'
@@ -63,13 +64,13 @@ compose run --rm worker aleph upgrade
 printf '%s\n' 'Waiting for the web interface...'
 attempt=0
 until curl -fsS http://localhost:8080/ >/dev/null 2>&1; do
-    attempt=$((attempt + 1))
-    if [ "$attempt" -ge 60 ]; then
-        printf '%s\n' 'The web interface did not become available within 5 minutes.' >&2
-        printf '%s\n' 'Inspect services with: docker compose -f docker-compose.example.yml logs' >&2
-        exit 1
-    fi
-    sleep 5
+  attempt=$((attempt + 1))
+  if [ "$attempt" -ge 60 ]; then
+    printf '%s\n' 'The web interface did not become available within 5 minutes.' >&2
+    printf '%s\n' 'Inspect services with: docker compose -f docker-compose.example.yml logs' >&2
+    exit 1
+  fi
+  sleep 5
 done
 
 printf '%s\n' 'OpenAleph is running at http://localhost:8080/'

--- a/contrib/start-local.sh
+++ b/contrib/start-local.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# Start a single-user OpenAleph instance using the example Docker stack.
+
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+COMPOSE_FILE="$ROOT_DIR/docker-compose.example.yml"
+ENV_FILE="$ROOT_DIR/aleph.env"
+
+if ! command -v docker >/dev/null 2>&1; then
+    printf '%s\n' 'Docker is required. Install Docker and try again.' >&2
+    exit 1
+fi
+
+if ! docker compose version >/dev/null 2>&1; then
+    printf '%s\n' 'Docker Compose v2 is required. Install it and try again.' >&2
+    exit 1
+fi
+
+if ! command -v openssl >/dev/null 2>&1 || ! command -v curl >/dev/null 2>&1; then
+    printf '%s\n' 'openssl and curl are required. Install them and try again.' >&2
+    exit 1
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
+    secret_key=$(openssl rand -hex 32)
+    (
+        umask 077
+        sed \
+            -e "s/^ALEPH_SECRET_KEY=.*/ALEPH_SECRET_KEY=$secret_key/" \
+            -e 's/^ALEPH_SINGLE_USER=.*/ALEPH_SINGLE_USER=true/' \
+            "$ROOT_DIR/aleph.env.tmpl" >"$ENV_FILE"
+    )
+    printf '%s\n' 'Created aleph.env with a generated secret key and single-user mode enabled.'
+else
+    printf '%s\n' 'Using existing aleph.env without changes.'
+fi
+
+compose() {
+    docker compose -f "$COMPOSE_FILE" "$@"
+}
+
+printf '%s\n' 'Starting OpenAleph services...'
+compose up -d
+
+printf '%s\n' 'Waiting for Elasticsearch to become green...'
+attempt=0
+until compose exec -T elasticsearch curl -fsS \
+    'http://localhost:9200/_cluster/health?wait_for_status=green&timeout=1s' \
+    >/dev/null 2>&1; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge 120 ]; then
+        printf '%s\n' 'Elasticsearch did not become green within 10 minutes.' >&2
+        printf '%s\n' 'Inspect the service with: docker compose -f docker-compose.example.yml logs elasticsearch' >&2
+        exit 1
+    fi
+    sleep 5
+done
+
+printf '%s\n' 'Initializing the database and search index...'
+compose run --rm worker aleph upgrade
+
+printf '%s\n' 'Waiting for the web interface...'
+attempt=0
+until curl -fsS http://localhost:8080/ >/dev/null 2>&1; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge 60 ]; then
+        printf '%s\n' 'The web interface did not become available within 5 minutes.' >&2
+        printf '%s\n' 'Inspect services with: docker compose -f docker-compose.example.yml logs' >&2
+        exit 1
+    fi
+    sleep 5
+done
+
+printf '%s\n' 'OpenAleph is running at http://localhost:8080/'

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -40,6 +40,8 @@ services:
 
   ingest:
     image: ghcr.io/openaleph/ingest-file:${ALEPH_TAG:-latest}
+    # ingest-file is currently published only for AMD64.
+    platform: linux/amd64
     command: procrastinate worker -q ingest
     tmpfs:
       - /tmp:mode=777


### PR DESCRIPTION
I've had this onboarding improvement on my personal wishlist for a while:

`contrib/start-local.sh` does all the steps described in the "Get started" section of the README to get a development environment going. It picks single user mode for simplicity, generates a secret key and doesn't overwrite the `.env` file if it already exists.